### PR TITLE
BUGFIX: Dot-notated array path into schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -2269,7 +2269,8 @@ function Monoxide() {
 								examineStack.push({
 									node: d,
 									docPath: esDoc.docPath + '.' + pathSegment + '.' + i,
-									schemaPath: esDoc.schemaPath + '.' + pathSegment,
+									// FIXME: Why was this previously without the index?
+									schemaPath: esDoc.schemaPath + '.' + pathSegment + '.' + i,
 								})
 							});
 							examineStack[esDocIndex] = false;


### PR DESCRIPTION
Unsure why this previously had `schemaPath` different to `dataPath` and what consequences that may have.

